### PR TITLE
Fixes for regional BAM re-alignment with bgzipped inputs: glia: out_of_range and tabix errors

### DIFF
--- a/alignmentstats.cpp
+++ b/alignmentstats.cpp
@@ -34,7 +34,8 @@ void countMismatchesAndGaps(
         //cerr << l << t << " " << sp << " " << rp << endl;
         if (t == 'M') { // match or mismatch
             for (int i = 0; i < l; ++i) {
-                if (alignment.QueryBases.at(rp) != referenceSequence.at(sp)) {
+                if (sp >= referenceSequence.length() ||
+                      alignment.QueryBases.at(rp) != referenceSequence.at(sp)) {
                     ++stats.mismatches;
                     stats.mismatch_qsum += qualityChar2ShortInt(alignment.Qualities.at(rp));
                 }

--- a/main.cpp
+++ b/main.cpp
@@ -357,14 +357,9 @@ void realign_bam(Parameters& params) {
 
             // get variants for new DAG
             vector<vcf::Variant> variants;
-            if (!vcffile.setRegion(currentSeqname,
+            if (vcffile.setRegion(currentSeqname,
                                    dag_start_position,
                                    dag_start_position + ref.size())) {
-                cerr << "could not set region on VCF file to " << currentSeqname << ":"
-                     << dag_start_position << "-" << dag_start_position + ref.size()
-                     << endl;
-                exit(1);
-            } else {
                 while (vcffile.getNextVariant(var)) {
                     if (params.debug) cerr << "getting variant at " << var.sequenceName << ":" << var.position << endl;
                     if (var.position + var.ref.length() <= dag_start_position + ref.size()


### PR DESCRIPTION
Eric;
This fixes two issues I ran into while using glia for realignment included
called variants.
- It avoid erroring out when tabix region retrieval has no variants. The current
  logic would fail both on tabix retrieval due to a return problem with vcflib
  (fixed at https://github.com/ekg/vcflib/pull/28) and in regions which don't
  have any variants where setRegion returns false. The fix checks the logic but
  avoids erroring out, instead only iterating over variants if they are present.
- Avoids `std::out_of_range` errors from `referenceSequence.at(sp)` when an
  alignment falls over the end of reference sequence. The fix counts these as
  mismatches.

Here's a small reproducible test case that triggers these errors.

```
wget https://github.com/chapmanb/bcbio.variation.plus/raw/master/test/data/ensemble/NA12878-10.bam
wget https://raw.github.com/chapmanb/bcbio.variation.plus/master/test/data/ensemble/chr10-start.fa
wget https://s3.amazonaws.com/chapmanb/union-10_250000_400000.vcf.gz
tabix -p vcf union-10_250000_400000.vcf.gz
samtools view -bu NA12878-10.bam | glia -d -Rr -w 1000 -S 200 -Q 200 -G 4 -f chr10-start.fa -v union-10_250000_400000.vcf.gz
```

Thanks again for this tool. I'm excited to have a minimal test case running with
it and looking forward to exploring more.
